### PR TITLE
Ajout de l'utilisation de trivy dans les tests

### DIFF
--- a/MLflow/README.md
+++ b/MLflow/README.md
@@ -10,6 +10,9 @@ docker build . -t mlflow:v1 --no-cache
 
 ```bash
 docker run -it --rm mlflow:v1 mlflow --help
+
+trivy image --scanners vuln,secret,misconfig,license --license-full --severity CRITICAL,HIGH mlflow:v1
+trivy fs --scanners config .
 ```
 
 ### Utilisation de l'image


### PR DESCRIPTION
[SonarQube/Trivy ](https://www.aquasec.com/products/trivy/) permet de scanner les images docker à la recherche de logiciels ayant des CVE connues.